### PR TITLE
Add Heroku url to ALLOWED_HOSTS without https://

### DIFF
--- a/happython/settings.py
+++ b/happython/settings.py
@@ -29,7 +29,7 @@ SECRET_KEY = 'SECRET_KEY'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['8000-brokenhelix-happiness-onv51o1rw0g.ws-eu110.gitpod.io', 'https://happiness-generator-c0a5ad8756d8.herokuapp.com']
+ALLOWED_HOSTS = ['8000-brokenhelix-happiness-onv51o1rw0g.ws-eu110.gitpod.io', 'happiness-generator-c0a5ad8756d8.herokuapp.com']
 
 
 # Application definition


### PR DESCRIPTION
Add Heroku url to ALLOWED_HOSTS without https://